### PR TITLE
Migrate to tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,15 @@ version = "0.1.1"
 authors = ["paul@colomiets.name"]
 
 [dependencies]
-tokio-core = "0.1.10"
+tokio = "0.1.5"
 tokio-io = "0.1.3"
+tokio-timer = "0.2.1"
 futures = "0.1.16"
 log = "0.3.7"
 
 [dev-dependencies]
 tk-http = "0.3.1"
+tokio-core = "0.1.10"
 env_logger = "0.4.2"
 abstract-ns = "0.4.0"
 ns-env-config = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ authors = ["paul@colomiets.name"]
 [dependencies]
 tokio = "0.1.5"
 tokio-io = "0.1.3"
-tokio-timer = "0.2.1"
 futures = "0.1.16"
 log = "0.3.7"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,6 @@
 
 extern crate futures;
 extern crate tokio;
-extern crate tokio_timer;
 
 #[macro_use] extern crate log;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use futures::{Stream, IntoFuture};
-use tokio_core::reactor::Handle;
 
 use sleep_on_error;
 use listen;
@@ -18,11 +17,11 @@ pub trait ListenExt: Stream {
     /// Turns a listening stream that you can get from `TcpListener::incoming`
     /// into a stream that supresses errors and sleeps on resource shortage,
     /// effectively allowing listening stream to resume on error.
-    fn sleep_on_error(self, delay: Duration, handle: &Handle)
+    fn sleep_on_error(self, delay: Duration)
         -> sleep_on_error::SleepOnError<Self>
         where Self: Sized,
     {
-        sleep_on_error::new(self, delay, handle)
+        sleep_on_error::new(self, delay)
     }
     /// Turns a stream of protocol handlers usually produced by mapping
     /// a stream of accepted cnnec


### PR DESCRIPTION
Adapt crate to use `tokio` instead of `tokio-core` due to expected
deprecation of latter.

With the response to [Issue 1](https://github.com/tailhook/tk-listen/issues/1). Please consider.
Nevertheless it seems that currently there is no possibility to adapt examples [http.rs](https://github.com/tailhook/tk-listen/blob/master/examples/http.rs) which uses [tk-http](https://crates.io/crates/tk-http), and [use_ns.rs](https://github.com/tailhook/tk-listen/blob/master/examples/use_ns.rs) which uses [ns-env-config](https://crates.io/crates/ns-env-config) since they're based on `tokio-core`. Since that it's possibly better to leave this pull request in the pending status until mentioned crates are adapted too.