### PR TITLE
Use tokio::clock::now instead of Instant::now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.2.0"
 authors = ["paul@colomiets.name"]
 
 [dependencies]
-tokio = "0.1.5"
+tokio = "0.1.7"
 tokio-io = "0.1.3"
 futures = "0.1.16"
 log = "0.4.1"

--- a/examples/alternating.rs
+++ b/examples/alternating.rs
@@ -7,8 +7,9 @@ extern crate env_logger;
 
 use std::io::Write;
 use std::env;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
+use tokio::clock;
 use tokio::runtime::Runtime;
 use tokio::timer::{Delay, Interval};
 
@@ -40,7 +41,7 @@ fn main() {
         listener
         .sleep_on_error(Duration::from_millis(100))
         .map(move |mut socket| {
-            Delay::new(Instant::now() + Duration::from_millis(500))
+            Delay::new(clock::now() + Duration::from_millis(500))
             .map(move |_| socket.write(b"hello\n"))
             .map(|result| {
                 match result {
@@ -55,7 +56,7 @@ fn main() {
 
     tokio::run(
         Interval::new(
-            Instant::now() + Duration::new(5, 0),
+            clock::now() + Duration::new(5, 0),
             Duration::new(5, 0)
         )
             .for_each(move |_| {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -7,8 +7,9 @@ extern crate env_logger;
 
 use std::io::Write;
 use std::env;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
+use tokio::clock;
 use tokio::net::TcpListener;
 use tokio::runtime::run;
 use tokio::timer::Delay;
@@ -30,7 +31,7 @@ fn main() {
         listener.incoming()
         .sleep_on_error(Duration::from_millis(100))
         .map(move |mut socket| {
-            Delay::new(Instant::now() + Duration::from_millis(500))
+            Delay::new(clock::now() + Duration::from_millis(500))
             .map(move |_| socket.write(b"hello\n"))
             .map(|result| {
                 match result {

--- a/src/bind.rs
+++ b/src/bind.rs
@@ -2,10 +2,11 @@ use std::collections::HashMap;
 use std::io;
 use std::mem;
 use std::net::SocketAddr;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use futures::{Future, Stream, Async};
 use tokio::net::{TcpListener, Incoming, TcpStream};
+use tokio::clock;
 use tokio::timer::Delay;
 
 
@@ -148,7 +149,7 @@ impl<S> Stream for BindMany<S>
                     }
                     if backlog.len() > 0 {
                         self.retry_timer = Some((
-                            Delay::new(Instant::now() + self.retry_interval),
+                            Delay::new(clock::now() + self.retry_interval),
                             backlog));
                     } else {
                         self.retry_timer = None;
@@ -181,7 +182,7 @@ impl<S> Stream for BindMany<S>
                         }
                         if backlog.len() > 0 {
                             *timer = Delay::new(
-                                Instant::now() + self.retry_interval
+                                clock::now() + self.retry_interval
                             );
                             continue;  // need to poll timer
                         }

--- a/src/sleep_on_error.rs
+++ b/src/sleep_on_error.rs
@@ -1,7 +1,8 @@
 use std::io;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use futures::{Future, Stream, Async};
+use tokio::clock;
 use tokio::timer::Delay;
 
 
@@ -56,7 +57,7 @@ impl<I, S: Stream<Item=I, Error=io::Error>> Stream for SleepOnError<S> {
                 Err(e) => {
                     debug!("Accept error: {}. Sleeping {:?}...",
                         e, self.delay);
-                    let mut delay = Delay::new(Instant::now() + self.delay);
+                    let mut delay = Delay::new(clock::now() + self.delay);
                     let result = delay.poll()
                         .expect("delay never fails");
                     match result {


### PR DESCRIPTION
Tokio applications should prefer that one because:
* Tokio may be able to cache the syscall (eg. do it once every loop
  turn), increasing performance.
* This is what Delay and Interval use under the hood anyway.
* May be mocked in tests, but that works in sane way only if everything
  uses the clock::now().

Fixes #5